### PR TITLE
fix:broken image of soundloud icon in arturia template

### DIFF
--- a/templates/arturia.mjml
+++ b/templates/arturia.mjml
@@ -2,77 +2,256 @@
   <mj-body background-color="#F2F2F2">
     <mj-section vertical-align="center" padding-bottom="0px">
       <mj-column vertical-align="middle">
-        <mj-image width="144px" align="center" src="https://www.arturia.com/images/newsletters/2016-02-black/Logo-Baseline-0.15x.png" href="https://www.arturia.com" alt=""></mj-image>
+        <mj-image
+          width="144px"
+          align="center"
+          src="https://www.arturia.com/images/newsletters/2016-02-black/Logo-Baseline-0.15x.png"
+          href="https://www.arturia.com"
+          alt=""
+        ></mj-image>
       </mj-column>
       <mj-column></mj-column>
       <mj-column>
-        <mj-text font-family="Helvetica,Arial,sans-serif" line-height="120%" text-decoration="underline" align="left">NEWS<br />MARCH 2016</mj-text>
+        <mj-text
+          font-family="Helvetica,Arial,sans-serif"
+          line-height="120%"
+          text-decoration="underline"
+          align="left"
+          >NEWS<br />MARCH 2016</mj-text
+        >
       </mj-column>
     </mj-section>
     <mj-section background-color="#000001">
       <mj-column>
-        <mj-text padding-top="0px" padding-bottom="0px" color="#FFFFFE" font-family="Helvetica,Arial,sans-serif" font-size="14px" line-height="120%">Dear {firstname}, <br /><br /> You used to follow rhythm, now rhythm follows you, everywhere you go!<br /> Discover iSpark, the mobile transposition of our renowned beat-making solution Spark.</mj-text>
+        <mj-text
+          padding-top="0px"
+          padding-bottom="0px"
+          color="#FFFFFE"
+          font-family="Helvetica,Arial,sans-serif"
+          font-size="14px"
+          line-height="120%"
+          >Dear {firstname}, <br /><br />
+          You used to follow rhythm, now rhythm follows you, everywhere you
+          go!<br />
+          Discover iSpark, the mobile transposition of our renowned beat-making
+          solution Spark.</mj-text
+        >
       </mj-column>
     </mj-section>
     <mj-section>
       <mj-column background-color="#FFFFFE">
-        <mj-image padding-bottom="0px" padding-top="0px" padding-left="0px" padding-right="0px" src="https://www.arturia.com/images/newsletters/2016-02-ispark/05.jpg" href="https://www.arturia.com/products/ipad-synths/ispark/overview" alt=""></mj-image>
-        <mj-text padding-top="25px" padding-bottom="25px" font-family="Helvetica,Arial,sans-serif" font-size="14px" line-height="120%">iSpark is a powerful mobile production tool allowing you to create and play rhythmic tracks, complex grooves and even complete songs. Its sonic strike force comes along with an unwavering workflow and a real flexibility.</mj-text>
+        <mj-image
+          padding-bottom="0px"
+          padding-top="0px"
+          padding-left="0px"
+          padding-right="0px"
+          src="https://www.arturia.com/images/newsletters/2016-02-ispark/05.jpg"
+          href="https://www.arturia.com/products/ipad-synths/ispark/overview"
+          alt=""
+        ></mj-image>
+        <mj-text
+          padding-top="25px"
+          padding-bottom="25px"
+          font-family="Helvetica,Arial,sans-serif"
+          font-size="14px"
+          line-height="120%"
+          >iSpark is a powerful mobile production tool allowing you to create
+          and play rhythmic tracks, complex grooves and even complete songs. Its
+          sonic strike force comes along with an unwavering workflow and a real
+          flexibility.</mj-text
+        >
       </mj-column>
     </mj-section>
     <mj-section>
       <mj-column background-color="#FFFFFE">
-        <mj-image padding-bottom="0px" padding-top="0px" padding-left="0px" padding-right="0px" src="https://www.arturia.com/images/newsletters/2016-02-ispark/06.jpg" href="https://www.arturia.com/products/ipad-synths/ispark/overview" alt=""></mj-image>
-        <mj-text padding-top="25px" padding-bottom="25px" font-family="Helvetica,Arial,sans-serif" font-size="14px" line-height="120%">Check out the iSpark introduction movie shot during the Arturia Experience event at the ADE featuring the Dutch beatmaker FilosofischeStilte.</mj-text>
+        <mj-image
+          padding-bottom="0px"
+          padding-top="0px"
+          padding-left="0px"
+          padding-right="0px"
+          src="https://www.arturia.com/images/newsletters/2016-02-ispark/06.jpg"
+          href="https://www.arturia.com/products/ipad-synths/ispark/overview"
+          alt=""
+        ></mj-image>
+        <mj-text
+          padding-top="25px"
+          padding-bottom="25px"
+          font-family="Helvetica,Arial,sans-serif"
+          font-size="14px"
+          line-height="120%"
+          >Check out the iSpark introduction movie shot during the Arturia
+          Experience event at the ADE featuring the Dutch beatmaker
+          FilosofischeStilte.</mj-text
+        >
       </mj-column>
     </mj-section>
     <mj-section>
       <mj-column background-color="#FFFFFE">
-        <mj-image padding-bottom="0px" padding-top="0px" padding-left="0px" padding-right="0px" src="https://www.arturia.com/images/newsletters/2016-02-ispark/07.jpg" href="https://www.arturia.com/products/ipad-synths/ispark/details" alt=""></mj-image>
-        <mj-text padding-top="25px" padding-bottom="25px" font-family="Helvetica,Arial,sans-serif" font-size="14px" line-height="120%">Follow Mauricio Garcia, Arturia Product Specialist, presenting you the many clever features of iSpark in this series of tutorials.</mj-text>
+        <mj-image
+          padding-bottom="0px"
+          padding-top="0px"
+          padding-left="0px"
+          padding-right="0px"
+          src="https://www.arturia.com/images/newsletters/2016-02-ispark/07.jpg"
+          href="https://www.arturia.com/products/ipad-synths/ispark/details"
+          alt=""
+        ></mj-image>
+        <mj-text
+          padding-top="25px"
+          padding-bottom="25px"
+          font-family="Helvetica,Arial,sans-serif"
+          font-size="14px"
+          line-height="120%"
+          >Follow Mauricio Garcia, Arturia Product Specialist, presenting you
+          the many clever features of iSpark in this series of
+          tutorials.</mj-text
+        >
       </mj-column>
     </mj-section>
     <mj-section>
       <mj-column background-color="#FFFFFE">
-        <mj-image padding-bottom="0px" padding-top="0px" padding-left="0px" padding-right="0px" src="https://www.arturia.com/images/newsletters/2016-02-ispark/08.jpg" href="https://www.arturia.com/products/ipad-synths/ispark/details" alt=""></mj-image>
-        <mj-text padding-top="25px" font-family="Helvetica,Arial,sans-serif" font-size="14px" line-height="120%">iSpark includes a tremendous collection of factory kits and individual instruments covering most of the field of application of beat-making but it is also compatible with the existing Spark resources and Expansion Packs.</mj-text>
-        <mj-button background-color="#2DDCB4"
-          padding-bottom="25px" border-radius="8px" href="https://www.arturia.com/products/ipad-synths/ispark/overview" font-size="14px" font-family="Helvetica,Arial,sans-serif" line-height="120%">Learn more about iSpark</mj-button>
+        <mj-image
+          padding-bottom="0px"
+          padding-top="0px"
+          padding-left="0px"
+          padding-right="0px"
+          src="https://www.arturia.com/images/newsletters/2016-02-ispark/08.jpg"
+          href="https://www.arturia.com/products/ipad-synths/ispark/details"
+          alt=""
+        ></mj-image>
+        <mj-text
+          padding-top="25px"
+          font-family="Helvetica,Arial,sans-serif"
+          font-size="14px"
+          line-height="120%"
+          >iSpark includes a tremendous collection of factory kits and
+          individual instruments covering most of the field of application of
+          beat-making but it is also compatible with the existing Spark
+          resources and Expansion Packs.</mj-text
+        >
+        <mj-button
+          background-color="#2DDCB4"
+          padding-bottom="25px"
+          border-radius="8px"
+          href="https://www.arturia.com/products/ipad-synths/ispark/overview"
+          font-size="14px"
+          font-family="Helvetica,Arial,sans-serif"
+          line-height="120%"
+          >Learn more about iSpark</mj-button
+        >
       </mj-column>
     </mj-section>
     <mj-section background-color="#000001">
       <mj-column>
-        <mj-text color="#FFFFFE" font-family="Helvetica,Arial,sans-serif" font-size="14px">Musically yours,<br /> The Arturia Team</mj-text>
+        <mj-text
+          color="#FFFFFE"
+          font-family="Helvetica,Arial,sans-serif"
+          font-size="14px"
+          >Musically yours,<br />
+          The Arturia Team</mj-text
+        >
       </mj-column>
     </mj-section>
-    <mj-section padding-left="0px" padding-right="0px" padding-top="0px" padding-bottom="0px">
+    <mj-section
+      padding-left="0px"
+      padding-right="0px"
+      padding-top="0px"
+      padding-bottom="0px"
+    >
       <mj-column>
-        <mj-image width="86px" src="https://www.arturia.com/images/newsletters/2016-02-ispark/facebook_arturia.png" href="http://www.facebook.com/arturia2" alt=""></mj-image>
+        <mj-image
+          width="86px"
+          src="https://www.arturia.com/images/newsletters/2016-02-ispark/facebook_arturia.png"
+          href="http://www.facebook.com/arturia2"
+          alt=""
+        ></mj-image>
       </mj-column>
       <mj-column>
-        <mj-image width="86px" src="https://www.arturia.com/images/newsletters/2016-02-ispark/youtube.png" href="http://www.youtube.com/arturiaweb" alt=""></mj-image>
+        <mj-image
+          width="86px"
+          src="https://www.arturia.com/images/newsletters/2016-02-ispark/youtube.png"
+          href="http://www.youtube.com/arturiaweb"
+          alt=""
+        ></mj-image>
       </mj-column>
       <mj-column>
-        <mj-image width="86px" src="https://www.arturia.com/images/newsletters/2016-02-ispark/Soundcloud.png" href="http://soundcloud.com/arturia-official" alt=""></mj-image>
+        <mj-image
+          width="86px"
+          src="https://www.arturia.com/images/newsletters/2016-02-ispark/soundcloud.png"
+          href="http://soundcloud.com/arturia-official"
+          alt=""
+        ></mj-image>
       </mj-column>
       <mj-column>
-        <mj-image width="86px" src="https://www.arturia.com/images/newsletters/2016-02-ispark/twitter_arturia.png" href="http://twitter.com/arturiaofficial" alt=""></mj-image>
+        <mj-image
+          width="86px"
+          src="https://www.arturia.com/images/newsletters/2016-02-ispark/twitter_arturia.png"
+          href="http://twitter.com/arturiaofficial"
+          alt=""
+        ></mj-image>
       </mj-column>
     </mj-section>
     <mj-section padding-top="0px" padding-bottom="0px">
       <mj-column>
-        <mj-text font-family="Helvetica,Arial,sans-serif" padding-top="0px" align="center">See this email in your browser <a href="https://www.arturia.com/images/newsletters/2016-02-ispark/newsletter.html" style="text-decoration:none;color:#2DDCB4">here</a></mj-text>
+        <mj-text
+          font-family="Helvetica,Arial,sans-serif"
+          padding-top="0px"
+          align="center"
+          >See this email in your browser
+          <a
+            href="https://www.arturia.com/images/newsletters/2016-02-ispark/newsletter.html"
+            style="text-decoration: none; color: #2ddcb4"
+            >here</a
+          ></mj-text
+        >
         <mj-divider padding-left="0px" padding-right="0px"></mj-divider>
       </mj-column>
     </mj-section>
     <mj-section padding-bottom="0px" padding-top="0px">
       <mj-column>
-        <mj-text padding-bottom="0px" padding-top="0px" font-family="Helvetica,Arial,sans-serif" font-size="10px" line-height="12px">Your email address is on this list as a result of a subscription, information request, competition, or other correspondence you may have had with us in the past. If you would like to be removed from our list, check the email address this newsletter
-          was sent to and use the following link: <a href="https://www.arturia.com/index.php?option=com_myarturia&view=newsletter&task=unsubscribeFromEmail&email={email}&token={title}&utm_source=elasticemail&utm_medium=email&utm_campaign=arturia_unsubscribe_2016&utm_term=nl-ispark-launch&utm_content=unsubscribe_footer"
-            style="text-decoration:none;color:#2DDCB4">Unsubscribe</a>. Privacy policy available <a href="https://www.arturia.com/privacypolicy" style="text-decoration:none;color:#2DDCB4">here</a>.</mj-text>
-        <mj-text padding-bottom="0px" font-family="Helvetica,Arial,sans-serif"
-          font-size="10px" line-height="12px">ARTURIA: <a href="https://www.arturia.com" style="text-decoration:none;color:#2DDCB4">https://www.arturia.com</a> - Contact: <a href="mailto:info@arturia.com" style="text-decoration:none;color:#2DDCB4">info</a><br /> ARTURIA France: 30 chemin
-          du vieux chêne, 38240 Meylan - FRANCE<br /> ARTURIA US: : 5776-D Lindero Cyn Rd #239 -Westlake Village, CA 91362 - USA</mj-text>
+        <mj-text
+          padding-bottom="0px"
+          padding-top="0px"
+          font-family="Helvetica,Arial,sans-serif"
+          font-size="10px"
+          line-height="12px"
+          >Your email address is on this list as a result of a subscription,
+          information request, competition, or other correspondence you may have
+          had with us in the past. If you would like to be removed from our
+          list, check the email address this newsletter was sent to and use the
+          following link:
+          <a
+            href="https://www.arturia.com/index.php?option=com_myarturia&view=newsletter&task=unsubscribeFromEmail&email={email}&token={title}&utm_source=elasticemail&utm_medium=email&utm_campaign=arturia_unsubscribe_2016&utm_term=nl-ispark-launch&utm_content=unsubscribe_footer"
+            style="text-decoration: none; color: #2ddcb4"
+            >Unsubscribe</a
+          >. Privacy policy available
+          <a
+            href="https://www.arturia.com/privacypolicy"
+            style="text-decoration: none; color: #2ddcb4"
+            >here</a
+          >.</mj-text
+        >
+        <mj-text
+          padding-bottom="0px"
+          font-family="Helvetica,Arial,sans-serif"
+          font-size="10px"
+          line-height="12px"
+          >ARTURIA:
+          <a
+            href="https://www.arturia.com"
+            style="text-decoration: none; color: #2ddcb4"
+            >https://www.arturia.com</a
+          >
+          - Contact:
+          <a
+            href="mailto:info@arturia.com"
+            style="text-decoration: none; color: #2ddcb4"
+            >info</a
+          ><br />
+          ARTURIA France: 30 chemin du vieux chêne, 38240 Meylan - FRANCE<br />
+          ARTURIA US: : 5776-D Lindero Cyn Rd #239 -Westlake Village, CA 91362 -
+          USA</mj-text
+        >
         <mj-divider padding-left="0px" padding-right="0px"></mj-divider>
       </mj-column>
     </mj-section>


### PR DESCRIPTION
Description: Minor fix on broken image of soundcloud icon in Arturia template

From:
<img width="625" alt="Screen Shot 2023-07-23 at 2 41 55 PM" src="https://github.com/mjmlio/email-templates/assets/91102425/cc7169d6-a920-4fd7-9b96-f5e0d2e0af12">

To:
<img width="626" alt="Screen Shot 2023-07-23 at 2 42 08 PM" src="https://github.com/mjmlio/email-templates/assets/91102425/c409211b-3f02-4f32-b659-2da9bf1f23db">
